### PR TITLE
Server-side vesting classification (v0.5.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,20 +4,37 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-The Unicity WEB GUI Wallet is a self-contained, browser-based cryptocurrency wallet for the Unicity network. The entire application runs in a single HTML file (`index.html`, 12871 lines, 888KB) with embedded JavaScript and CSS, requiring no build process or external dependencies. It supports the Alpha cryptocurrency on the consensus layer (PoW blockchain) with architecture designed for future offchain layer integration.
+The Unicity WEB GUI Wallet (v0.4.9) is a self-contained, browser-based cryptocurrency wallet for the Unicity network. The entire application runs in a single HTML file (`index.html`, ~14,000 lines) with embedded JavaScript and CSS, requiring no build process. It supports the Alpha cryptocurrency on the consensus layer (PoW blockchain).
 
-## Key Architecture
+## Development Commands
+
+```bash
+# Run the wallet (no build needed)
+python3 -m http.server 8000  # open http://localhost:8000/index.html
+# Or open index.html directly in browser
+
+# Test scripts for wallet.dat analysis
+npm install
+node decrypt_and_derive.js           # Full decryption + BIP32 derivation
+node analyze_encrypted_wallet.js     # Analyze encrypted wallet structure
+node test_wallet_decryption.js       # Test decryption logic
+
+# Debug service (Express server, port 3487)
+cd debug-service && npm install && npm start
+
+# Migration script (requires alpha-cli)
+./alpha-migrate.sh <private_key_wif> <wallet_name>
+
+# Create GitHub release
+./create_release.sh  # Update version in script first
+```
+
+## Architecture
 
 ### Single-File Design
-- **index.html**: Complete wallet application (888KB) containing:
-  - Embedded CryptoJS library for AES, PBKDF2, SHA-512
-  - Embedded elliptic.js for secp256k1 curve operations
-  - BIP32/BIP44 HD wallet implementation
-  - Bech32 encoding for SegWit addresses
-  - QR code generation library
-  - Fulcrum WebSocket integration
-  - Complete UI with tabbed interface
-  - All crypto operations run client-side in browser
+- `index.html` contains the complete wallet with embedded CryptoJS, elliptic.js, BIP32/BIP44 HD wallet, Bech32 encoding, QR code generation, and Fulcrum WebSocket client
+- All crypto runs client-side; no server dependencies
+- Use `offset`/`limit` when reading with the Read tool due to file size
 
 ### Cryptographic Stack
 - **Key Generation**: Web Crypto API → 32 bytes entropy → secp256k1 keypair
@@ -26,191 +43,73 @@ The Unicity WEB GUI Wallet is a self-contained, browser-based cryptocurrency wal
 - **Wallet Encryption**: AES-256 with PBKDF2 (100,000 iterations)
 
 ### Operating Modes
-1. **Full Wallet**: Private key control for sending/receiving
-2. **Watch-Only**: Monitor addresses without private keys
-3. **Online**: Connected to Fulcrum for real-time blockchain data
-4. **Offline**: Create/sign transactions without network
+- **Full Wallet**: Private key control for sending/receiving
+- **Watch-Only**: Monitor addresses without private keys
+- **Online/Offline**: Connected to Fulcrum or air-gapped
 
-## Core Functions
+### Storage
+- IndexedDB primary, localStorage fallback
+- All sensitive data encrypted before storage
+
+## Core Functions (line numbers approximate)
 
 ### Wallet Management
-- `initializeWallet()`: Generate master key from secure entropy (line ~1980)
+- `initializeWallet()` (~1980): Generate master key from secure entropy
 - `generateNewAddress()`: Derive child keys via BIP32
-- `restoreFromWalletDat(file)`: Import Alpha wallet.dat (SQLite) (line ~3083)
-  - Auto-detects: descriptor wallets, legacy HD, legacy non-HD, encrypted wallets
-  - Extracts DER-encoded private keys from SQLite binary format
-  - Searches for patterns: `walletdescriptorkey`, `hdchain`, `mkey` (encryption), `ckey` (encrypted keys)
-  - Triggers address scanning for BIP32 wallets (up to 100 addresses)
-- `decryptAndImportWallet()`: Decrypt encrypted wallet.dat files (line ~3450)
-  - Prompts for password when encrypted wallet detected
-  - Uses SHA-512 key derivation (Bitcoin Core compatible)
-  - Decrypts master key with AES-256-CBC
-  - Extracts chain code from wallet descriptors
-  - Derives BIP32 addresses from decrypted master key
-- Multi-wallet support: Switch between multiple wallets stored in localStorage/IndexedDB
+- `restoreFromWalletDat(file)` (~3083): Import wallet.dat (SQLite binary parsing)
+  - Auto-detects: descriptor, legacy HD, legacy non-HD, encrypted wallets
+  - Pattern matching: `walletdescriptorkey`, `hdchain`, `mkey`, `ckey`
+- `decryptAndImportWallet()` (~3450): Decrypt encrypted wallet.dat files
 
 ### Transaction Handling
 - `createTransaction()`: Build with UTXO selection
-- `signTransaction()`: Offline signing capability
+- `signTransaction()`: Offline signing
 - `broadcastTransaction()`: Submit via Fulcrum
-- `updateTransactionHistory()`: Paginated display (20/page)
-- `updateUtxoListDisplay()`: Paginated UTXOs (20/page)
+- `updateTransactionHistory()`, `updateUtxoListDisplay()`: Paginated (20/page)
 
 ### Fulcrum Integration
 - `connectToElectrumServer()`: WebSocket connection
 - `subscribeToAddressChanges()`: Real-time updates
 - `refreshBalance()`: Fetch UTXOs and balance
 
-## Development Commands
+## Wallet.dat Import
 
-```bash
-# Run the main wallet application
-open index.html
-# Or serve locally
-python3 -m http.server 8000
-# Navigate to http://localhost:8000/index.html
+### Binary Format
+- SQLite-based with direct binary parsing (no sql.js dependency)
+- DER-encoded private keys
+- Supports: descriptor (modern), legacy HD, legacy non-HD, encrypted
 
-# Migrate wallet to Alpha Core node
-./alpha-migrate.sh <private_key_wif> <wallet_name>
+### Encryption (Bitcoin Core Compatible)
+- SHA-512 for key derivation, AES-256-CBC encryption
+- `mkey` records: encrypted master key + derivation parameters
+- `ckey` records: individually encrypted keys
 
-# Run debug service (for collecting debug reports from wallets)
-cd debug-service
-npm install
-npm start        # Production mode on port 3487
-npm run dev      # Development mode with auto-restart
+### Address Scanning
+- Auto-scans up to 100 addresses for BIP32 wallets after import
+- Chain code extraction required for BIP32 derivation
 
-# Test scripts for wallet.dat analysis (root directory, require Node.js + dependencies)
-npm install      # Install dependencies: elliptic, sqlite3, bip32, etc.
-node analyze_encrypted_wallet.js    # Analyze encrypted wallet structure
-node test_wallet_decryption.js      # Test wallet decryption logic
-node decrypt_wallet_standard.js     # Decrypt and extract keys
-node compare_dat_files.js           # Compare multiple wallet files
-node decrypt_and_derive.js          # Full decryption and address derivation
-# See individual .js files for more analysis/testing utilities
+## Test Scripts
 
-# Create release
-./create_release.sh    # Creates GitHub release with index.html
-```
+Root directory contains Node.js utilities for wallet.dat debugging (require `npm install`):
+- `analyze_*.js` - Examine wallet structure and encryption
+- `decrypt_*.js` - Test decryption with various wallet types
+- `test_*.js` - Validate address derivation and BIP32
+- `find_*.js` - Search for specific keys/paths
 
-## Migration Script
-
-The `alpha-migrate.sh` script imports wallet private keys to Alpha Core:
-1. Creates/uses specified wallet
-2. Imports key using `wpkh()` descriptor format
-3. Verifies import and checks balance
-4. Provides rescan instructions if needed
-
-## Critical Implementation Details
-
-1. **No Build Process**: Direct HTML file execution, no npm/webpack required
-2. **Child Key Export**: Exports derived keys (not master key) for security
-3. **Address Scanning**: Auto-scans up to 100 addresses for BIP32 wallets after import
-4. **Wallet.dat Formats**: Supports descriptor (modern), legacy HD, legacy non-HD, and encrypted formats
-5. **Encrypted Wallet Support**: Can decrypt and import encrypted wallet.dat files with `mkey` records
-6. **Storage**: IndexedDB primary, localStorage fallback for cross-tab persistence
-7. **Multi-Wallet**: Supports multiple wallets with wallet switching functionality
-8. **Auto-Hide**: Private keys hidden after 30 seconds for security
-9. **Pagination**: 20 items per page for transactions/UTXOs
-10. **Binary Parsing**: Direct SQLite binary parsing without SQL-js dependency
-
-## Testing Focus Areas
-
-- SegWit address generation (`alpha1` prefix)
-- Wallet.dat import (descriptor, legacy, encrypted formats)
-- BIP32 address scanning functionality (100 address limit)
-- Encryption/decryption with various passwords
-- Online/offline mode transitions
-- QR code generation/scanning
-- Migration script functionality
-- Watch-only mode operations
-- Pagination for large datasets
-- Multi-wallet switching
-- Binary SQLite parsing accuracy
+Test wallet files are in `ref_materials/`.
 
 ## Debug Service
 
-The `debug-service/` directory contains a standalone Node.js microservice for collecting and analyzing debug reports:
-- **Purpose**: Collects debug reports from wallet instances for troubleshooting
-- **API Endpoints**: Submit reports, list reports, extract/export transactions
-- **Web Interface**: Browse reports at http://localhost:3487
-- **Storage**: File-based storage organized by date in `reports/` directory
-- **Security**: Rate limiting (100 req/15min), CORS protection, 10MB size limit
+Express.js microservice in `debug-service/` (port 3487):
+- Collects wallet debug reports via `/api/submit-report`
+- Stores reports in `reports/` directory by date
+- Serves wallet at `/wallet` for testing
+- Supports HTTPS with certificates in `debug-service/ssl/`
 
-## Analysis Scripts
+## Key Implementation Details
 
-The repository includes Node.js utilities for wallet.dat analysis and testing in the root directory:
-- **analyze_*.js**: Examine wallet structure, encryption, and key formats
-  - `analyze_encrypted_wallet.js`: Detect mkey records and encryption metadata
-  - `analyze_mkey_format.js`: Parse master key structure
-- **decrypt_*.js**: Test decryption logic with various wallet types
-  - `decrypt_wallet_standard.js`: Standard Bitcoin Core wallet decryption
-  - `decrypt_and_derive.js`: Full decryption + BIP32 address derivation
-  - `decrypt_enc_wallet2.js`, `decrypt_enc_wallet2_full.js`: Specific test cases
-- **test_*.js**: Validate address derivation, BIP32 functionality
-  - `test_bip32_steps.js`: Step-by-step BIP32 derivation testing
-  - `test_wallet_decryption.js`: End-to-end decryption validation
-- **compare_dat_files.js**: Compare multiple wallet.dat files side-by-side
-- **find_*.js**: Search for specific keys or derivation paths (e.g., `find_derivation_path.js`)
-
-These scripts require root-level `node_modules/` dependencies (elliptic, sqlite3, bip32, bs58check, tiny-secp256k1) and are used for debugging wallet import issues. They work with wallet.dat files placed in `ref_materials/` or specified paths.
-
-## Reference Materials
-
-The `ref_materials/` directory contains test wallet.dat files and reference data:
-- Contains symbolic link to Alpha Core wallet directory for testing
-- Houses encrypted wallet.dat files for testing decryption logic
-- Test files referenced by analysis scripts (e.g., `enc_wallet2.dat`)
-
-## Project Structure
-
-```
-/
-├── index.html                    # Main wallet application (888KB single file)
-├── alpha-migrate.sh             # Migration script to Alpha Core
-├── create_release.sh            # GitHub release automation
-├── package.json                 # Root dependencies for test scripts
-├── *.js                         # Analysis/testing scripts (20+ files)
-├── debug-service/               # Standalone debug report collector
-│   ├── server.js               # Express server (port 3487)
-│   ├── package.json            # Service dependencies
-│   └── public/                 # Web interface
-└── ref_materials/              # Test wallet.dat files
-```
-
-## Important Implementation Considerations
-
-### Working with index.html
-- **Single massive file**: All code, CSS, and libraries embedded in one 888KB HTML file
-- **No build process**: Edit HTML directly, test by opening in browser
-- **Embedded libraries**: CryptoJS, elliptic.js, and other crypto libraries are inline
-- **Line numbers matter**: Functions referenced by approximate line numbers (may shift with edits)
-- **Reading the file**: Use offset/limit parameters when using Read tool due to 12K+ lines
-
-### Wallet.dat Binary Format
-- **SQLite-based**: Uses direct binary parsing, not SQL-js
-- **Multiple formats**: Descriptor (modern), legacy HD, legacy non-HD, encrypted (mkey)
-- **DER encoding**: Private keys stored as DER-encoded values in binary
-- **Pattern matching**: Search for byte patterns like `walletdescriptorkey`, `hdchain`, `mkey`, `ckey`
-- **Chain code extraction**: Required for BIP32 derivation from wallet descriptors
-
-### Encryption Implementation
-- **Bitcoin Core compatible**: Uses SHA-512 for key derivation (not PBKDF2 like wallet.dat format)
-- **AES-256-CBC**: Same encryption as Bitcoin Core for compatibility
-- **Master key (mkey)**: Contains encrypted master key + derivation parameters
-- **Encrypted keys (ckey)**: Individual key encryption with public key as identifier
-
-### Testing Wallet Import
-- Use test files in `ref_materials/` directory
-- Alpha Core symlink points to actual blockchain wallet directory
-- Test both encrypted and unencrypted wallet.dat files
-- Verify address scanning produces expected `alpha1` addresses
-- Test with various wallet ages (different descriptor versions)
-
-## Future Offchain Layer Integration Points
-
-When implementing offchain support:
-1. Add layer selection UI
-2. Implement state channel management
-3. Add cross-layer transfer mechanisms
-4. Update balance displays for both layers
-5. Implement offchain transaction formats
+1. **Child Key Export**: Exports derived keys (not master) for security
+2. **Auto-Hide**: Private keys hidden after 30 seconds
+3. **Transaction Queue**: Rate limited to 30 per block, auto-retry on failure
+4. **Vesting Classification**: Queue-based UTXO classification with persistent TXO cache
+5. **Balance Verification**: Fulcrum direct balance verification with loading spinner

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-The Unicity WEB GUI Wallet (v0.4.9) is a self-contained, browser-based cryptocurrency wallet for the Unicity network. The entire application runs in a single HTML file (`index.html`, ~14,000 lines) with embedded JavaScript and CSS, requiring no build process. It supports the Alpha cryptocurrency on the consensus layer (PoW blockchain).
+The Unicity WEB GUI Wallet (v0.4.10) is a self-contained, browser-based cryptocurrency wallet for the Unicity network. The entire application runs in a single HTML file (`index.html`, ~14,000 lines) with embedded JavaScript and CSS, requiring no build process. It supports the Alpha cryptocurrency on the consensus layer (PoW blockchain).
 
 ## Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-The Unicity WEB GUI Wallet (v0.4.10) is a self-contained, browser-based cryptocurrency wallet for the Unicity network. The entire application runs in a single HTML file (`index.html`, ~14,000 lines) with embedded JavaScript and CSS, requiring no build process. It supports the Alpha cryptocurrency on the consensus layer (PoW blockchain).
+The Unicity WEB GUI Wallet (v0.5.0) is a self-contained, browser-based cryptocurrency wallet for the Unicity network. The entire application runs in a single HTML file (`index.html`, ~14,000 lines) with embedded JavaScript and CSS, requiring no build process. It supports the Alpha cryptocurrency on the consensus layer (PoW blockchain).
 
 ## Development Commands
 

--- a/index.html
+++ b/index.html
@@ -661,7 +661,7 @@
 </head>
 <body>
     <!-- Version Number -->
-    <div style="position: fixed; top: 10px; right: 10px; font-size: 10px; color: #999; z-index: 1000; font-family: monospace;">v0.4.10</div>
+    <div style="position: fixed; top: 10px; right: 10px; font-size: 10px; color: #999; z-index: 1000; font-family: monospace;">v0.5.0</div>
     
     <!-- Notification Container -->
     <div id="notificationContainer" class="notification-container"></div>
@@ -817,7 +817,7 @@
                     <circle cx="12" cy="12" r="2"></circle>
                     <path d="M6 12h.01M18 12h.01"></path>
                 </svg>
-                Unicity WEB GUI Wallet v0.4.10
+                Unicity WEB GUI Wallet v0.5.0
             </h1>
         </div>
         
@@ -4153,6 +4153,14 @@ Anyone with your master private key can access all your funds.`;
                 const countedBalance = runningVestedBalance + runningUnvestedBalance;
                 const spinner = document.getElementById('balanceVerificationSpinner');
 
+                // Skip verification until Fulcrum direct balance has been fetched.
+                // Without this guard, the async fetchFulcrumDirectBalance hasn't returned yet
+                // and fulcrumDirectBalance is 0n, causing a false "overshoot" retry cascade.
+                if (fulcrumDirectBalance === 0n && countedBalance > 0n) {
+                    console.log('[BalanceVerify] Waiting for Fulcrum direct balance fetch...');
+                    return;
+                }
+
                 console.log(`[BalanceVerify] Counted: ${SatoshiMath.satoshisToAlpha(countedBalance)} ALPHA, Fulcrum: ${SatoshiMath.satoshisToAlpha(fulcrumDirectBalance)} ALPHA`);
 
                 if (countedBalance === fulcrumDirectBalance) {
@@ -4186,19 +4194,13 @@ Anyone with your master private key can access all your funds.`;
                 setTimeout(() => {
                     const currentAddress = getCurrentVestingAddress();
                     if (currentAddress) {
-                        // Reset running balances
-                        runningVestedBalance = 0n;
-                        runningUnvestedBalance = 0n;
-                        unconfirmedVestedBalance = 0n;
-                        unconfirmedUnvestedBalance = 0n;
-
-                        // Re-fetch both balance and UTXOs
+                        // Re-fetch Fulcrum direct balance
                         fetchFulcrumDirectBalance(currentAddress);
-                        // Use the correct refresh function for the current mode
-                        if (watchOnlyMode && watchOnlyAddressValue) {
-                            refreshWatchOnlyBalance(watchOnlyAddressValue);
-                        } else {
-                            refreshBalance();
+                        // Force reclassification from current UTXOs (processIncomingUtxos
+                        // resets running balances internally). This bypasses the
+                        // hasUtxoArrayChanged guard which would otherwise skip reprocessing.
+                        if (currentUtxos && currentUtxos.length > 0) {
+                            processIncomingUtxos(currentUtxos, currentAddress);
                         }
                     }
                 }, BALANCE_RETRY_INTERVAL);
@@ -14326,7 +14328,7 @@ Anyone with your master private key can access all your funds.`;
                 sessions: transactionDebugLog,
                 readyToImport: failedTxs,
                 metadata: {
-                    walletVersion: 'v0.4.10',
+                    walletVersion: 'v0.5.0',
                     timestamp: new Date().toISOString(),
                     userAgent: navigator.userAgent,
                     totalSessions: transactionDebugLog.length,

--- a/index.html
+++ b/index.html
@@ -8680,13 +8680,16 @@ Anyone with your master private key can access all your funds.`;
                             
                             updateUtxoListDisplay();
                             updateCommonBalance(); // This will update Send button state
+
+                            // Process UTXOs through server-aware classification
+                            processIncomingUtxos(currentUtxos, address);
                         }
-                        
+
                         // Also update UTXO list display after fetching UTXOs
                         updateUtxoListDisplay();
                     }
                 });
-                
+
                 // Also fetch transaction history
                 electrumRequest('blockchain.scripthash.get_history', [scriptHash], function(result) {
                     if (result !== null && result !== undefined) {
@@ -8980,7 +8983,8 @@ Anyone with your master private key can access all your funds.`;
 
                 // Trigger vesting classification if connected
                 if (electrumConnected && currentUtxos && currentUtxos.length > 0) {
-                    classifyAllUtxos();
+                    const currentAddress = getCurrentVestingAddress();
+                    processIncomingUtxos(currentUtxos, currentAddress);
                 }
             }
 

--- a/index.html
+++ b/index.html
@@ -3665,13 +3665,16 @@ Anyone with your master private key can access all your funds.`;
                 // Clear existing queue (new batch = fresh start)
                 utxoProcessingQueue.length = 0;
 
+                // Check if these UTXOs have server-provided vesting fields
+                const utxosHaveVestingField = utxos.length > 0 && utxos.some(u => u.vested !== undefined);
+
                 // Auto-detect server vesting support from UTXO data
-                if (!serverProvidesVesting && utxos.length > 0 && utxos[0].vested !== undefined) {
+                if (!serverProvidesVesting && utxosHaveVestingField) {
                     serverProvidesVesting = true;
                     console.log('[ServerVesting] Detected server-side vesting support from UTXO data');
                 }
 
-                console.log(`[TxoQueue] Processing ${utxos.length} UTXOs for ${forAddress}`);
+                console.log(`[TxoQueue] Processing ${utxos.length} UTXOs for ${forAddress} (serverVesting=${serverProvidesVesting}, utxosHaveField=${utxosHaveVestingField})`);
 
                 // Fetch Fulcrum direct balance for verification
                 fetchFulcrumDirectBalance(forAddress);
@@ -3680,7 +3683,7 @@ Anyone with your master private key can access all your funds.`;
                 const spinner = document.getElementById('balanceVerificationSpinner');
                 if (spinner) spinner.style.display = 'inline';
 
-                if (serverProvidesVesting) {
+                if (serverProvidesVesting && utxosHaveVestingField) {
                     // SERVER-SIDE VESTING: instant classification from Fulcrum data
                     for (const utxo of utxos) {
                         const isVested = utxo.vested === true;
@@ -3706,9 +3709,19 @@ Anyone with your master private key can access all your funds.`;
 
                     updateVestingBalanceDisplayRealtime();
                     syncToAddressVestingCacheFromUtxos(utxos, forAddress);
+                    // Refresh UTXO list to show vesting colors
+                    updateUtxoListDisplay();
                     // Hide spinner immediately - no async work needed
                     if (spinner) spinner.style.display = 'none';
                     console.log(`[ServerVesting] Instant classification: ${utxos.length} UTXOs (vested: ${SatoshiMath.satoshisToAlpha(runningVestedBalance)}, unvested: ${SatoshiMath.satoshisToAlpha(runningUnvestedBalance)})`);
+                    return;
+                }
+
+                // Server provides vesting but these UTXOs are stale (from cache/previous session)
+                // Skip classification — fresh listunspent response will have the vesting fields
+                if (serverProvidesVesting && !utxosHaveVestingField) {
+                    console.log(`[ServerVesting] Skipping classification: UTXOs lack vesting fields (stale data), waiting for fresh server response`);
+                    if (spinner) spinner.style.display = 'none';
                     return;
                 }
 
@@ -8648,45 +8661,38 @@ Anyone with your master private key can access all your funds.`;
                 // Fetch UTXOs
                 electrumRequest('blockchain.scripthash.listunspent', [scriptHash], function(result) {
                     if (result !== null && result !== undefined) {
-                        // Always update if UTXOs changed OR if we cleared them OR if result is empty
-                        const shouldUpdate = hasArrayChanged(currentUtxos, result) || currentUtxos.length === 0 || result.length === 0;
-                        if (shouldUpdate) {
-                            // Add address to each UTXO
-                            currentUtxos = result.map(utxo => ({
-                                ...utxo,
-                                address: address
-                            }));
-                            
-                            // Calculate balances using BigInt for precision
-                            let confirmed = 0n;
-                            let unconfirmed = 0n;
+                        // Always update currentUtxos from server (picks up new fields like vested)
+                        currentUtxos = result.map(utxo => ({
+                            ...utxo,
+                            address: address
+                        }));
 
-                            result.forEach(utxo => {
-                                if (utxo.height > 0) {
-                                    confirmed += BigInt(utxo.value);
-                                } else {
-                                    unconfirmed += BigInt(utxo.value);
-                                }
-                            });
+                        // Calculate balances using BigInt for precision
+                        let confirmed = 0n;
+                        let unconfirmed = 0n;
 
-                            // Update display - use Fulcrum's direct balance when available
-                            const displayBalance = fulcrumDirectBalance > 0n ? fulcrumDirectBalance : confirmed;
-                            watchOnlyBalance.textContent = SatoshiMath.satoshisToAlpha(displayBalance) + ' ALPHA';
-                            if (unconfirmed > 0n) {
-                                watchOnlyUnconfirmed.textContent = '(' + SatoshiMath.satoshisToAlpha(unconfirmed) + ')';
+                        result.forEach(utxo => {
+                            if (utxo.height > 0) {
+                                confirmed += BigInt(utxo.value);
                             } else {
-                                watchOnlyUnconfirmed.textContent = '';
+                                unconfirmed += BigInt(utxo.value);
                             }
-                            
-                            updateUtxoListDisplay();
-                            updateCommonBalance(); // This will update Send button state
+                        });
 
-                            // Process UTXOs through server-aware classification
-                            processIncomingUtxos(currentUtxos, address);
+                        // Update display - use Fulcrum's direct balance when available
+                        const displayBalance = fulcrumDirectBalance > 0n ? fulcrumDirectBalance : confirmed;
+                        watchOnlyBalance.textContent = SatoshiMath.satoshisToAlpha(displayBalance) + ' ALPHA';
+                        if (unconfirmed > 0n) {
+                            watchOnlyUnconfirmed.textContent = '(' + SatoshiMath.satoshisToAlpha(unconfirmed) + ')';
+                        } else {
+                            watchOnlyUnconfirmed.textContent = '';
                         }
 
-                        // Also update UTXO list display after fetching UTXOs
                         updateUtxoListDisplay();
+                        updateCommonBalance(); // This will update Send button state
+
+                        // Process UTXOs through server-aware classification
+                        processIncomingUtxos(currentUtxos, address);
                     }
                 });
 
@@ -8981,11 +8987,6 @@ Anyone with your master private key can access all your funds.`;
                 // Handle watch-only mode visibility
                 updateWatchOnlyMode();
 
-                // Trigger vesting classification if connected
-                if (electrumConnected && currentUtxos && currentUtxos.length > 0) {
-                    const currentAddress = getCurrentVestingAddress();
-                    processIncomingUtxos(currentUtxos, currentAddress);
-                }
             }
 
             /**
@@ -9324,23 +9325,23 @@ Anyone with your master private key can access all your funds.`;
                     }
                 }
                 
-                // Vesting visual indicators
+                // Vesting visual indicators (only for classified outputs)
                 const vestingColors = {
                     vested: '#ef4444',
                     unvested: '#4CAF50',
-                    mixed: '#2196F3',
-                    unknown: '#fbbf24'
+                    mixed: '#2196F3'
                 };
                 const vestingLabels = {
                     vested: 'Locked',
                     unvested: 'Unlocked',
-                    mixed: 'Mixed',
-                    unknown: 'Unknown'
+                    mixed: 'Mixed'
                 };
-                const borderColor = vestingColors[vestingStatus] || vestingColors.unknown;
+                const borderColor = vestingColors[vestingStatus] || null;
                 const vestingLabel = vestingLabels[vestingStatus] || '';
 
-                txDiv.style.borderLeft = `3px solid ${borderColor}`;
+                if (borderColor) {
+                    txDiv.style.borderLeft = `3px solid ${borderColor}`;
+                }
                 txDiv.setAttribute('data-vesting', vestingStatus);
 
                 const vestingBadgeHtml = vestingLabel ?
@@ -9647,6 +9648,7 @@ Anyone with your master private key can access all your funds.`;
                     isIncoming,
                     netAmount: Math.abs(netAmount),
                     destinations,
+                    ourOutputs,
                     senderAddress,
                     fromAddresses
                 };
@@ -10359,7 +10361,7 @@ Anyone with your master private key can access all your funds.`;
 
                     // Determine UTXO vesting status from cache
                     const utxoClassification = txoClassificationCache.get(utxoKey);
-                    let utxoVestingColor = '#fbbf24'; // yellow = unknown
+                    let utxoVestingColor = null;
                     let utxoVestingLabel = '';
                     if (utxoClassification) {
                         if (utxoClassification.isVested) {
@@ -10371,11 +10373,12 @@ Anyone with your master private key can access all your funds.`;
                         }
                     }
 
+                    const borderStyle = utxoVestingColor ? `border-left: 3px solid ${utxoVestingColor};` : '';
                     // Style based on consumption status
                     if (isConsumed) {
-                        utxoDiv.style.cssText = `padding: 8px; background-color: #e5e7eb; border-radius: 4px; margin-bottom: 6px; font-size: 11px; opacity: 0.6; border-left: 3px solid ${utxoVestingColor};`;
+                        utxoDiv.style.cssText = `padding: 8px; background-color: #e5e7eb; border-radius: 4px; margin-bottom: 6px; font-size: 11px; opacity: 0.6; ${borderStyle}`;
                     } else {
-                        utxoDiv.style.cssText = `padding: 8px; background-color: #f8f9fa; border-radius: 4px; margin-bottom: 6px; font-size: 11px; border-left: 3px solid ${utxoVestingColor};`;
+                        utxoDiv.style.cssText = `padding: 8px; background-color: #f8f9fa; border-radius: 4px; margin-bottom: 6px; font-size: 11px; ${borderStyle}`;
                     }
 
                     const utxoBadgeHtml = utxoVestingLabel ?
@@ -11281,20 +11284,17 @@ Anyone with your master private key can access all your funds.`;
                         // Store UTXOs
                         electrumRequest('blockchain.scripthash.listunspent', [scriptHash], function(result) {
                             if (result) {
-                                // Only update if UTXOs changed
-                                if (hasArrayChanged(currentUtxos, result)) {
-                                    const currentAddress = wallet.addresses[0].address;
-                                    // Add address to each UTXO
-                                    currentUtxos = result.map(utxo => ({
-                                        ...utxo,
-                                        address: currentAddress
-                                    }));
-                                    updateCommonBalance();
-                                    updateUtxoListDisplay();
+                                const currentAddress = wallet.addresses[0].address;
+                                // Always update currentUtxos from server (picks up new fields like vested)
+                                currentUtxos = result.map(utxo => ({
+                                    ...utxo,
+                                    address: currentAddress
+                                }));
+                                updateCommonBalance();
+                                updateUtxoListDisplay();
 
-                                    // NEW: Process UTXOs through queue-based classification system
-                                    processIncomingUtxos(currentUtxos, currentAddress);
-                                }
+                                // Process UTXOs through server-aware classification
+                                processIncomingUtxos(currentUtxos, currentAddress);
                             }
                         });
                     }

--- a/index.html
+++ b/index.html
@@ -629,11 +629,11 @@
         }
 
         .vesting-color-vested {
-            color: #4CAF50;
+            color: #ef4444;
         }
 
         .vesting-color-unvested {
-            color: #FF9800;
+            color: #4CAF50;
         }
 
         .vesting-row-all .vesting-mode-name {
@@ -646,11 +646,11 @@
         }
 
         .vesting-row-vested.selected {
-            background-color: rgba(76, 175, 80, 0.08);
+            background-color: rgba(239, 68, 68, 0.08);
         }
 
         .vesting-row-unvested.selected {
-            background-color: rgba(255, 152, 0, 0.08);
+            background-color: rgba(76, 175, 80, 0.08);
         }
 
         @keyframes spin {
@@ -9222,6 +9222,7 @@ Anyone with your master private key can access all your funds.`;
                 const txDiv = document.createElement('div');
                 txDiv.style.cssText = 'padding: 15px; border-bottom: 1px solid #e9ecef; font-size: 14px;';
                 txDiv.setAttribute('data-txid', txid);
+                txDiv.setAttribute('data-vesting', 'pending');
                 
                 let statusColor = confirmations > 0 ? '#34d399' : '#fbbf24';
                 let statusText = confirmations > 0 ? `${confirmations} confirmations` : 'Unconfirmed';
@@ -9239,6 +9240,9 @@ Anyone with your master private key can access all your funds.`;
                 let amountColor = '#9ca3af';
                 let amountSign = '';
                 
+                // Vesting status for this transaction: 'vested', 'unvested', 'mixed', or 'unknown'
+                let vestingStatus = 'unknown';
+
                 if (!isLoading) {
                     // Calculate net amount and direction from full transaction details
                     const result = calculateTransactionAmount(txDetails, ourAddress);
@@ -9246,7 +9250,23 @@ Anyone with your master private key can access all your funds.`;
                     amount = SatoshiMath.satoshisToAlpha(Math.abs(result.netAmount));
                     destinations = result.destinations;
                     senderAddress = result.senderAddress;
-                    
+
+                    // Determine vesting status from our outputs in this transaction
+                    if (result.ourOutputs && result.ourOutputs.length > 0) {
+                        let hasVested = false, hasUnvested = false;
+                        for (const out of result.ourOutputs) {
+                            const cacheKey = `${txid}:${out.vout}`;
+                            const cached = txoClassificationCache.get(cacheKey);
+                            if (cached) {
+                                if (cached.isVested) hasVested = true;
+                                else hasUnvested = true;
+                            }
+                        }
+                        if (hasVested && hasUnvested) vestingStatus = 'mixed';
+                        else if (hasVested) vestingStatus = 'vested';
+                        else if (hasUnvested) vestingStatus = 'unvested';
+                    }
+
                     // Set direction text and colors based on transaction type
                     if (!ourAddress) {
                         // No wallet loaded - show neutral transaction
@@ -9304,6 +9324,28 @@ Anyone with your master private key can access all your funds.`;
                     }
                 }
                 
+                // Vesting visual indicators
+                const vestingColors = {
+                    vested: '#ef4444',
+                    unvested: '#4CAF50',
+                    mixed: '#2196F3',
+                    unknown: '#fbbf24'
+                };
+                const vestingLabels = {
+                    vested: 'Locked',
+                    unvested: 'Unlocked',
+                    mixed: 'Mixed',
+                    unknown: 'Unknown'
+                };
+                const borderColor = vestingColors[vestingStatus] || vestingColors.unknown;
+                const vestingLabel = vestingLabels[vestingStatus] || '';
+
+                txDiv.style.borderLeft = `3px solid ${borderColor}`;
+                txDiv.setAttribute('data-vesting', vestingStatus);
+
+                const vestingBadgeHtml = vestingLabel ?
+                    `<span style="font-size: 10px; padding: 1px 6px; border-radius: 3px; background-color: ${borderColor}20; color: ${borderColor}; font-weight: 600; margin-left: 8px;">${vestingLabel}</span>` : '';
+
                 txDiv.innerHTML = `
                     <div style="display: flex; justify-content: space-between; align-items: start;">
                         <div style="flex: 1;">
@@ -9314,6 +9356,7 @@ Anyone with your master private key can access all your funds.`;
                                 <a href="${txLink}" target="_blank" style="font-family: monospace; font-size: 12px; color: #3b82f6; text-decoration: none;">
                                     ${truncatedTxid}
                                 </a>
+                                ${vestingBadgeHtml}
                             </div>
                             <div style="color: #666; font-size: 12px;">
                                 <span style="color: ${statusColor};">${statusText}</span>
@@ -10313,18 +10356,35 @@ Anyone with your master private key can access all your funds.`;
                     // Check if this UTXO is consumed
                     const utxoKey = `${txid}:${vout}`;
                     const isConsumed = consumedUtxos.has(utxoKey);
-                    
+
+                    // Determine UTXO vesting status from cache
+                    const utxoClassification = txoClassificationCache.get(utxoKey);
+                    let utxoVestingColor = '#fbbf24'; // yellow = unknown
+                    let utxoVestingLabel = '';
+                    if (utxoClassification) {
+                        if (utxoClassification.isVested) {
+                            utxoVestingColor = '#ef4444'; // red = locked
+                            utxoVestingLabel = 'Locked';
+                        } else {
+                            utxoVestingColor = '#4CAF50'; // green = unlocked
+                            utxoVestingLabel = 'Unlocked';
+                        }
+                    }
+
                     // Style based on consumption status
                     if (isConsumed) {
-                        utxoDiv.style.cssText = 'padding: 8px; background-color: #e5e7eb; border-radius: 4px; margin-bottom: 6px; font-size: 11px; opacity: 0.6;';
+                        utxoDiv.style.cssText = `padding: 8px; background-color: #e5e7eb; border-radius: 4px; margin-bottom: 6px; font-size: 11px; opacity: 0.6; border-left: 3px solid ${utxoVestingColor};`;
                     } else {
-                        utxoDiv.style.cssText = 'padding: 8px; background-color: #f8f9fa; border-radius: 4px; margin-bottom: 6px; font-size: 11px;';
+                        utxoDiv.style.cssText = `padding: 8px; background-color: #f8f9fa; border-radius: 4px; margin-bottom: 6px; font-size: 11px; border-left: 3px solid ${utxoVestingColor};`;
                     }
-                    
+
+                    const utxoBadgeHtml = utxoVestingLabel ?
+                        `<span style="font-size: 9px; padding: 1px 5px; border-radius: 3px; background-color: ${utxoVestingColor}20; color: ${utxoVestingColor}; font-weight: 600; margin-left: 6px;">${utxoVestingLabel}</span>` : '';
+
                     utxoDiv.innerHTML = `
                         <div style="display: flex; justify-content: space-between; align-items: center;">
                             <div style="flex: 1;">
-                                <div style="font-weight: 600; color: ${isConsumed ? '#6b7280' : '#06d6a0'};">${amount} ALPHA${source}${isConsumed ? ' (pending)' : ''}</div>
+                                <div style="font-weight: 600; color: ${isConsumed ? '#6b7280' : '#06d6a0'};">${amount} ALPHA${source}${isConsumed ? ' (pending)' : ''}${utxoBadgeHtml}</div>
                                 <div style="font-family: monospace; color: #666; word-break: break-all;">
                                     ${txid}:${vout}
                                 </div>

--- a/index.html
+++ b/index.html
@@ -661,7 +661,7 @@
 </head>
 <body>
     <!-- Version Number -->
-    <div style="position: fixed; top: 10px; right: 10px; font-size: 10px; color: #999; z-index: 1000; font-family: monospace;">v0.4.9</div>
+    <div style="position: fixed; top: 10px; right: 10px; font-size: 10px; color: #999; z-index: 1000; font-family: monospace;">v0.4.10</div>
     
     <!-- Notification Container -->
     <div id="notificationContainer" class="notification-container"></div>
@@ -817,7 +817,7 @@
                     <circle cx="12" cy="12" r="2"></circle>
                     <path d="M6 12h.01M18 12h.01"></path>
                 </svg>
-                Unicity WEB GUI Wallet v0.4.9
+                Unicity WEB GUI Wallet v0.4.10
             </h1>
         </div>
         
@@ -1720,6 +1720,9 @@ Anyone with your master private key can access all your funds.`;
 
             // Direct balance from Fulcrum for verification
             let fulcrumDirectBalance = 0n;
+
+            // Server-side vesting: true when connected Fulcrum provides vesting fields
+            let serverProvidesVesting = false;
             let balanceRetryCount = 0;
             const MAX_BALANCE_RETRIES = 10;
             const BALANCE_RETRY_INTERVAL = 2000;
@@ -3662,6 +3665,12 @@ Anyone with your master private key can access all your funds.`;
                 // Clear existing queue (new batch = fresh start)
                 utxoProcessingQueue.length = 0;
 
+                // Auto-detect server vesting support from UTXO data
+                if (!serverProvidesVesting && utxos.length > 0 && utxos[0].vested !== undefined) {
+                    serverProvidesVesting = true;
+                    console.log('[ServerVesting] Detected server-side vesting support from UTXO data');
+                }
+
                 console.log(`[TxoQueue] Processing ${utxos.length} UTXOs for ${forAddress}`);
 
                 // Fetch Fulcrum direct balance for verification
@@ -3671,6 +3680,39 @@ Anyone with your master private key can access all your funds.`;
                 const spinner = document.getElementById('balanceVerificationSpinner');
                 if (spinner) spinner.style.display = 'inline';
 
+                if (serverProvidesVesting) {
+                    // SERVER-SIDE VESTING: instant classification from Fulcrum data
+                    for (const utxo of utxos) {
+                        const isVested = utxo.vested === true;
+                        const classification = {
+                            isVested: isVested,
+                            coinbaseHeight: utxo.coinbase_height ?? null
+                        };
+                        // Populate in-memory cache
+                        const utxoKey = `${utxo.tx_hash}:${utxo.tx_pos}`;
+                        txoClassificationCache.set(utxoKey, classification);
+                        if (isVested) {
+                            runningVestedBalance += BigInt(utxo.value);
+                        } else {
+                            runningUnvestedBalance += BigInt(utxo.value);
+                        }
+                    }
+                    // Persist batch to IndexedDB
+                    const entries = utxos.map(u => ({
+                        key: `${u.tx_hash}:${u.tx_pos}`,
+                        classification: { isVested: u.vested === true, coinbaseHeight: u.coinbase_height ?? null }
+                    }));
+                    batchPersistTxosToIndexedDB(entries);
+
+                    updateVestingBalanceDisplayRealtime();
+                    syncToAddressVestingCacheFromUtxos(utxos, forAddress);
+                    // Hide spinner immediately - no async work needed
+                    if (spinner) spinner.style.display = 'none';
+                    console.log(`[ServerVesting] Instant classification: ${utxos.length} UTXOs (vested: ${SatoshiMath.satoshisToAlpha(runningVestedBalance)}, unvested: ${SatoshiMath.satoshisToAlpha(runningUnvestedBalance)})`);
+                    return;
+                }
+
+                // LEGACY: fall back to queue-based client-side tracing
                 for (const utxo of utxos) {
                     const utxoKey = `${utxo.tx_hash}:${utxo.tx_pos}`;
 
@@ -3937,6 +3979,39 @@ Anyone with your master private key can access all your funds.`;
             }
 
             /**
+             * Sync addressVestingCache from server-classified UTXOs (no tracing needed)
+             * @param {Array} utxos - UTXOs with server-provided vested field
+             * @param {string} address - The address these UTXOs belong to
+             */
+            function syncToAddressVestingCacheFromUtxos(utxos, address) {
+                if (!address) return;
+                const addressCache = getAddressVestingCache(address);
+                if (!addressCache) return;
+                const vested = [];
+                const unvested = [];
+                const all = [];
+
+                for (const utxo of utxos) {
+                    all.push(utxo);
+                    if (utxo.vested === true) {
+                        vested.push(utxo);
+                    } else {
+                        unvested.push(utxo);
+                    }
+                }
+
+                addressCache.classifiedUtxos = { vested, unvested, all };
+                addressCache.vestingBalances = {
+                    vested: runningVestedBalance,
+                    unvested: runningUnvestedBalance,
+                    all: fulcrumDirectBalance > 0n ? fulcrumDirectBalance : (runningVestedBalance + runningUnvestedBalance)
+                };
+
+                // Update static display
+                updateVestingBalanceDisplay();
+            }
+
+            /**
              * Clear classification queue (e.g., on wallet switch)
              */
             function clearClassificationQueue() {
@@ -4001,6 +4076,16 @@ Anyone with your master private key can access all your funds.`;
                     if (result && result.confirmed !== undefined) {
                         fulcrumDirectBalance = BigInt(result.confirmed);
                         console.log(`[BalanceVerify] Fulcrum direct balance: ${SatoshiMath.satoshisToAlpha(fulcrumDirectBalance)} ALPHA`);
+
+                        // Detect and use server-side vesting data from get_balance
+                        if (result.confirmed_vested !== undefined) {
+                            serverProvidesVesting = true;
+                            runningVestedBalance = BigInt(result.confirmed_vested);
+                            runningUnvestedBalance = BigInt(result.confirmed_unvested || 0);
+                            console.log(`[ServerVesting] Balance from server: vested=${SatoshiMath.satoshisToAlpha(runningVestedBalance)}, unvested=${SatoshiMath.satoshisToAlpha(runningUnvestedBalance)}`);
+                            updateVestingBalanceDisplayRealtime();
+                        }
+
                         checkBalanceVerification();
                     }
                 });
@@ -7953,6 +8038,7 @@ Anyone with your master private key can access all your funds.`;
                         // CRITICAL FIX: Clear the socket reference to prevent stale connections
                         electrumSocket = null;
                         electrumConnected = false;
+                        serverProvidesVesting = false;
                         currentScriptHashSubscription = null;
                         headerSubscriptionActive = false;
                         isInitialLoad = true;  // Reset for next connection
@@ -8076,6 +8162,7 @@ Anyone with your master private key can access all your funds.`;
                 }
 
                 electrumConnected = false;
+                serverProvidesVesting = false;
                 electrumCallbacks = {};
                 updateUtxoListDisplay(); // Update UTXO list display when disconnected
 
@@ -8902,6 +8989,11 @@ Anyone with your master private key can access all your funds.`;
              * This runs asynchronously after UTXOs are fetched
              */
             async function classifyAllUtxos() {
+                if (serverProvidesVesting) {
+                    console.log('[ServerVesting] Skipping client-side classification (server provides vesting)');
+                    return;
+                }
+
                 if (vestingClassificationInProgress) {
                     console.log('Vesting classification already in progress');
                     return;
@@ -12230,6 +12322,14 @@ Anyone with your master private key can access all your funds.`;
                             nextItem.status = 'complete';
                             nextItem.result = 'Already in mempool';
                             nextItem.completedAt = new Date().toISOString();
+                        } else if (error.message && error.message.includes('already in block')) {
+                            // Transaction already confirmed on blockchain - this is success, not failure
+                            nextItem.status = 'complete';
+                            nextItem.result = 'Already confirmed in blockchain';
+                            nextItem.completedAt = new Date().toISOString();
+                            broadcastDebug.log('success', 'Transaction already confirmed on blockchain', {
+                                txid: nextItem.tx.txid
+                            });
                         } else if (nextItem.attempts >= 3) {
                             // Max retries reached
                             nextItem.status = 'failed';
@@ -14056,7 +14156,7 @@ Anyone with your master private key can access all your funds.`;
                 sessions: transactionDebugLog,
                 readyToImport: failedTxs,
                 metadata: {
-                    walletVersion: 'v0.4.9',
+                    walletVersion: 'v0.4.10',
                     timestamp: new Date().toISOString(),
                     userAgent: navigator.userAgent,
                     totalSessions: transactionDebugLog.length,

--- a/index.html
+++ b/index.html
@@ -1717,6 +1717,9 @@ Anyone with your master private key can access all your funds.`;
             // Running balance totals (BigInt for precision) - updated during classification
             let runningVestedBalance = 0n;
             let runningUnvestedBalance = 0n;
+            // Unconfirmed (mempool) portions of vested/unvested balances
+            let unconfirmedVestedBalance = 0n;
+            let unconfirmedUnvestedBalance = 0n;
 
             // Direct balance from Fulcrum for verification
             let fulcrumDirectBalance = 0n;
@@ -3661,12 +3664,15 @@ Anyone with your master private key can access all your funds.`;
                 // Reset running balances for this batch
                 runningVestedBalance = 0n;
                 runningUnvestedBalance = 0n;
+                unconfirmedVestedBalance = 0n;
+                unconfirmedUnvestedBalance = 0n;
 
                 // Clear existing queue (new batch = fresh start)
                 utxoProcessingQueue.length = 0;
 
                 // Check if these UTXOs have server-provided vesting fields
-                const utxosHaveVestingField = utxos.length > 0 && utxos.some(u => u.vested !== undefined);
+                // Use strict boolean check — null/undefined means "not provided"
+                const utxosHaveVestingField = utxos.length > 0 && utxos.some(u => typeof u.vested === 'boolean');
 
                 // Auto-detect server vesting support from UTXO data
                 if (!serverProvidesVesting && utxosHaveVestingField) {
@@ -3683,22 +3689,30 @@ Anyone with your master private key can access all your funds.`;
                 const spinner = document.getElementById('balanceVerificationSpinner');
                 if (spinner) spinner.style.display = 'inline';
 
-                if (serverProvidesVesting && utxosHaveVestingField) {
+                if (utxosHaveVestingField) {
                     // SERVER-SIDE VESTING: instant classification from Fulcrum data
-                    for (const utxo of utxos) {
-                        const isVested = utxo.vested === true;
-                        const classification = {
-                            isVested: isVested,
-                            coinbaseHeight: utxo.coinbase_height ?? null
-                        };
-                        // Populate in-memory cache
-                        const utxoKey = `${utxo.tx_hash}:${utxo.tx_pos}`;
-                        txoClassificationCache.set(utxoKey, classification);
-                        if (isVested) {
-                            runningVestedBalance += BigInt(utxo.value);
-                        } else {
-                            runningUnvestedBalance += BigInt(utxo.value);
+                    try {
+                        for (const utxo of utxos) {
+                            const isVested = utxo.vested === true;
+                            const isUnconfirmed = !utxo.height || utxo.height <= 0;
+                            const classification = {
+                                isVested: isVested,
+                                coinbaseHeight: utxo.coinbase_height ?? null
+                            };
+                            // Populate in-memory cache
+                            const utxoKey = `${utxo.tx_hash}:${utxo.tx_pos}`;
+                            txoClassificationCache.set(utxoKey, classification);
+                            const val = BigInt(utxo.value ?? 0);
+                            if (isVested) {
+                                runningVestedBalance += val;
+                                if (isUnconfirmed) unconfirmedVestedBalance += val;
+                            } else {
+                                runningUnvestedBalance += val;
+                                if (isUnconfirmed) unconfirmedUnvestedBalance += val;
+                            }
                         }
+                    } catch (e) {
+                        console.error('[ServerVesting] Error classifying UTXOs:', e);
                     }
                     // Persist batch to IndexedDB
                     const entries = utxos.map(u => ({
@@ -3717,25 +3731,21 @@ Anyone with your master private key can access all your funds.`;
                     return;
                 }
 
-                // Server provides vesting but these UTXOs are stale (from cache/previous session)
-                // Skip classification — fresh listunspent response will have the vesting fields
-                if (serverProvidesVesting && !utxosHaveVestingField) {
-                    console.log(`[ServerVesting] Skipping classification: UTXOs lack vesting fields (stale data), waiting for fresh server response`);
-                    if (spinner) spinner.style.display = 'none';
-                    return;
-                }
-
-                // LEGACY: fall back to queue-based client-side tracing
+                // UTXOs lack vesting fields — fall through to legacy client-side tracing
+                // (even if serverProvidesVesting is true, stale/cached UTXOs still need classification)
                 for (const utxo of utxos) {
                     const utxoKey = `${utxo.tx_hash}:${utxo.tx_pos}`;
+                    const isUnconfirmed = !utxo.height || utxo.height <= 0;
 
                     if (txoClassificationCache.has(utxoKey)) {
                         // CACHE HIT - Already classified, use immediately
                         const cached = txoClassificationCache.get(utxoKey);
                         if (cached.isVested) {
                             runningVestedBalance += BigInt(utxo.value);
+                            if (isUnconfirmed) unconfirmedVestedBalance += BigInt(utxo.value);
                         } else {
                             runningUnvestedBalance += BigInt(utxo.value);
+                            if (isUnconfirmed) unconfirmedUnvestedBalance += BigInt(utxo.value);
                         }
                     } else {
                         // CACHE MISS - Add to queue for async classification
@@ -3798,13 +3808,17 @@ Anyone with your master private key can access all your funds.`;
                         progressTextEl.textContent = `${processed}/${totalToProcess} (${remaining} remaining)`;
                     }
 
+                    const isUnconfirmed = !utxo.height || utxo.height <= 0;
+
                     // Skip if somehow already cached (could happen during processing)
                     if (txoClassificationCache.has(utxo.key)) {
                         const cached = txoClassificationCache.get(utxo.key);
                         if (cached.isVested) {
                             runningVestedBalance += BigInt(utxo.value);
+                            if (isUnconfirmed) unconfirmedVestedBalance += BigInt(utxo.value);
                         } else {
                             runningUnvestedBalance += BigInt(utxo.value);
+                            if (isUnconfirmed) unconfirmedUnvestedBalance += BigInt(utxo.value);
                         }
                         updateVestingBalanceDisplayRealtime();
                         continue;
@@ -3828,8 +3842,10 @@ Anyone with your master private key can access all your funds.`;
                         // Update running balance
                         if (classification.isVested) {
                             runningVestedBalance += BigInt(utxo.value);
+                            if (isUnconfirmed) unconfirmedVestedBalance += BigInt(utxo.value);
                         } else {
                             runningUnvestedBalance += BigInt(utxo.value);
+                            if (isUnconfirmed) unconfirmedUnvestedBalance += BigInt(utxo.value);
                         }
 
                         // REAL-TIME UI UPDATE - watch the numbers grow!
@@ -3841,6 +3857,7 @@ Anyone with your master private key can access all your funds.`;
                         const errorClassification = { isVested: false, coinbaseHeight: null };
                         txoClassificationCache.set(utxo.key, errorClassification);
                         runningUnvestedBalance += BigInt(utxo.value);
+                        if (isUnconfirmed) unconfirmedUnvestedBalance += BigInt(utxo.value);
                         updateVestingBalanceDisplayRealtime();
                     }
 
@@ -3957,6 +3974,8 @@ Anyone with your master private key can access all your funds.`;
                 const vestedEl = document.getElementById('vestedBalance');
                 const unvestedEl = document.getElementById('unvestedBalance');
                 const totalEl = document.getElementById('walletBalance');
+                const vestedUnconfEl = document.getElementById('vestedUnconfirmed');
+                const unvestedUnconfEl = document.getElementById('unvestedUnconfirmed');
 
                 if (vestedEl) {
                     vestedEl.textContent = SatoshiMath.satoshisToAlpha(runningVestedBalance) + ' ALPHA';
@@ -3969,6 +3988,26 @@ Anyone with your master private key can access all your funds.`;
                     // Fall back to calculated sum if Fulcrum balance not yet fetched
                     const displayTotal = fulcrumDirectBalance > 0n ? fulcrumDirectBalance : (runningVestedBalance + runningUnvestedBalance);
                     totalEl.textContent = SatoshiMath.satoshisToAlpha(displayTotal) + ' ALPHA';
+                }
+
+                // Show unconfirmed vesting portions (matching total unconfirmed display style)
+                if (vestedUnconfEl) {
+                    if (unconfirmedVestedBalance > 0n) {
+                        vestedUnconfEl.style.display = 'inline';
+                        vestedUnconfEl.textContent = `(${SatoshiMath.satoshisToAlpha(unconfirmedVestedBalance)})`;
+                    } else {
+                        vestedUnconfEl.style.display = 'none';
+                        vestedUnconfEl.textContent = '';
+                    }
+                }
+                if (unvestedUnconfEl) {
+                    if (unconfirmedUnvestedBalance > 0n) {
+                        unvestedUnconfEl.style.display = 'inline';
+                        unvestedUnconfEl.textContent = `(${SatoshiMath.satoshisToAlpha(unconfirmedUnvestedBalance)})`;
+                    } else {
+                        unvestedUnconfEl.style.display = 'none';
+                        unvestedUnconfEl.textContent = '';
+                    }
                 }
 
                 // Check balance verification after updating display
@@ -4032,6 +4071,8 @@ Anyone with your master private key can access all your funds.`;
                 isProcessingUtxoQueue = false;  // Stop any ongoing processing
                 runningVestedBalance = 0n;
                 runningUnvestedBalance = 0n;
+                unconfirmedVestedBalance = 0n;
+                unconfirmedUnvestedBalance = 0n;
                 // Note: Do NOT clear txoClassificationCache - it's permanent!
                 console.log('[TxoQueue] Queue cleared');
             }
@@ -4086,18 +4127,19 @@ Anyone with your master private key can access all your funds.`;
                         console.error('[BalanceVerify] Error fetching Fulcrum balance:', error);
                         return;
                     }
-                    if (result && result.confirmed !== undefined) {
-                        fulcrumDirectBalance = BigInt(result.confirmed);
+                    if (result && result.confirmed != null) {
+                        // Include unconfirmed so total matches listunspent (which includes mempool UTXOs)
+                        try {
+                            fulcrumDirectBalance = BigInt(result.confirmed) + BigInt(result.unconfirmed || 0);
+                        } catch (e) {
+                            console.error('[BalanceVerify] Invalid balance value from server:', result, e);
+                            return;
+                        }
                         console.log(`[BalanceVerify] Fulcrum direct balance: ${SatoshiMath.satoshisToAlpha(fulcrumDirectBalance)} ALPHA`);
 
-                        // Detect and use server-side vesting data from get_balance
-                        if (result.confirmed_vested !== undefined) {
-                            serverProvidesVesting = true;
-                            runningVestedBalance = BigInt(result.confirmed_vested);
-                            runningUnvestedBalance = BigInt(result.confirmed_unvested || 0);
-                            console.log(`[ServerVesting] Balance from server: vested=${SatoshiMath.satoshisToAlpha(runningVestedBalance)}, unvested=${SatoshiMath.satoshisToAlpha(runningUnvestedBalance)}`);
-                            updateVestingBalanceDisplayRealtime();
-                        }
+                        // Note: serverProvidesVesting is set exclusively from UTXO data in
+                        // processIncomingUtxos to avoid race conditions where get_balance
+                        // arrives before listunspent with vesting fields.
 
                         checkBalanceVerification();
                     }
@@ -4147,10 +4189,17 @@ Anyone with your master private key can access all your funds.`;
                         // Reset running balances
                         runningVestedBalance = 0n;
                         runningUnvestedBalance = 0n;
+                        unconfirmedVestedBalance = 0n;
+                        unconfirmedUnvestedBalance = 0n;
 
                         // Re-fetch both balance and UTXOs
                         fetchFulcrumDirectBalance(currentAddress);
-                        refreshBalance(); // This should re-fetch UTXOs
+                        // Use the correct refresh function for the current mode
+                        if (watchOnlyMode && watchOnlyAddressValue) {
+                            refreshWatchOnlyBalance(watchOnlyAddressValue);
+                        } else {
+                            refreshBalance();
+                        }
                     }
                 }, BALANCE_RETRY_INTERVAL);
             }
@@ -8052,6 +8101,8 @@ Anyone with your master private key can access all your funds.`;
                         electrumSocket = null;
                         electrumConnected = false;
                         serverProvidesVesting = false;
+                        fulcrumDirectBalance = 0n;
+                        balanceRetryCount = 0;
                         currentScriptHashSubscription = null;
                         headerSubscriptionActive = false;
                         isInitialLoad = true;  // Reset for next connection
@@ -8176,6 +8227,8 @@ Anyone with your master private key can access all your funds.`;
 
                 electrumConnected = false;
                 serverProvidesVesting = false;
+                fulcrumDirectBalance = 0n;
+                balanceRetryCount = 0;
                 electrumCallbacks = {};
                 updateUtxoListDisplay(); // Update UTXO list display when disconnected
 
@@ -8661,11 +8714,14 @@ Anyone with your master private key can access all your funds.`;
                 // Fetch UTXOs
                 electrumRequest('blockchain.scripthash.listunspent', [scriptHash], function(result) {
                     if (result !== null && result !== undefined) {
-                        // Always update currentUtxos from server (picks up new fields like vested)
-                        currentUtxos = result.map(utxo => ({
+                        const newUtxos = result.map(utxo => ({
                             ...utxo,
                             address: address
                         }));
+
+                        // Only reprocess if UTXOs actually changed (prevents flicker and redundant work)
+                        const utxosChanged = hasUtxoArrayChanged(currentUtxos, newUtxos);
+                        currentUtxos = newUtxos;
 
                         // Calculate balances using BigInt for precision
                         let confirmed = 0n;
@@ -8691,8 +8747,10 @@ Anyone with your master private key can access all your funds.`;
                         updateUtxoListDisplay();
                         updateCommonBalance(); // This will update Send button state
 
-                        // Process UTXOs through server-aware classification
-                        processIncomingUtxos(currentUtxos, address);
+                        // Only reprocess classification when UTXOs changed
+                        if (utxosChanged) {
+                            processIncomingUtxos(currentUtxos, address);
+                        }
                     }
                 });
 
@@ -9216,7 +9274,9 @@ Anyone with your master private key can access all your funds.`;
 
             // Format transaction for display
             function formatTransactionDisplay(tx, ourAddress, confirmations, txDetails) {
-                const txid = tx.tx_hash || tx.txid || tx.id;
+                const rawTxid = tx.tx_hash || tx.txid || tx.id || '';
+                // Sanitize txid: must be hex only (prevents innerHTML injection)
+                const txid = rawTxid.replace(/[^a-fA-F0-9]/g, '');
                 const truncatedTxid = txid.substring(0, 6) + '...' + txid.substring(txid.length - 6);
                 const txLink = `https://www.unicity.network/tx/${txid}`;
                 
@@ -9283,6 +9343,9 @@ Anyone with your master private key can access all your funds.`;
                     }
                 }
                 
+                // Sanitize address for safe innerHTML use (alphanumeric + bech32 chars only)
+                const sanitizeAddr = (a) => (a || '').replace(/[^a-zA-Z0-9]/g, '');
+
                 let addressHtml = '';
                 if (isLoading) {
                     // Show loading state for address
@@ -9293,22 +9356,24 @@ Anyone with your master private key can access all your funds.`;
                     if (fromAddresses.length > 0) {
                         // Remove duplicates
                         fromAddresses = [...new Set(fromAddresses)];
-                        
+
                         addressHtml += '<div style="margin-top: 5px; font-size: 12px; color: #666;">From: ';
                         fromAddresses.forEach((addr, idx) => {
                             if (idx > 0) addressHtml += ', ';
-                            const truncAddr = addr.substring(0, 11) + '...' + addr.substring(addr.length - 6);
-                            addressHtml += `<a href="https://www.unicity.network/address/${addr}" target="_blank" style="color: #3b82f6; text-decoration: none;">${truncAddr}</a>`;
+                            const safeAddr = sanitizeAddr(addr);
+                            const truncAddr = safeAddr.substring(0, 11) + '...' + safeAddr.substring(safeAddr.length - 6);
+                            addressHtml += `<a href="https://www.unicity.network/address/${safeAddr}" target="_blank" style="color: #3b82f6; text-decoration: none;">${truncAddr}</a>`;
                         });
                         addressHtml += '</div>';
                     }
-                    
+
                     // For incoming transactions, show sender
                     if (isIncoming && senderAddress && fromAddresses.length === 0) {
-                        const truncAddr = senderAddress.substring(0, 11) + '...' + senderAddress.substring(senderAddress.length - 6);
-                        addressHtml += `<div style="margin-top: 5px; font-size: 12px; color: #666;">From: <a href="https://www.unicity.network/address/${senderAddress}" target="_blank" style="color: #3b82f6; text-decoration: none;">${truncAddr}</a></div>`;
+                        const safeSender = sanitizeAddr(senderAddress);
+                        const truncAddr = safeSender.substring(0, 11) + '...' + safeSender.substring(safeSender.length - 6);
+                        addressHtml += `<div style="margin-top: 5px; font-size: 12px; color: #666;">From: <a href="https://www.unicity.network/address/${safeSender}" target="_blank" style="color: #3b82f6; text-decoration: none;">${truncAddr}</a></div>`;
                     }
-                    
+
                     // Show destinations
                     if (destinations.length > 0) {
                         // If no wallet is loaded (ourAddress is null), show all destinations
@@ -9317,8 +9382,9 @@ Anyone with your master private key can access all your funds.`;
                             addressHtml += '<div style="margin-top: 5px; font-size: 12px; color: #666;">To: ';
                             destinations.forEach((dest, idx) => {
                                 if (idx > 0) addressHtml += ', ';
-                                const truncAddr = dest.address.substring(0, 11) + '...' + dest.address.substring(dest.address.length - 6);
-                                addressHtml += `<a href="https://www.unicity.network/address/${dest.address}" target="_blank" style="color: #3b82f6; text-decoration: none;">${truncAddr}</a>`;
+                                const safeDest = sanitizeAddr(dest.address);
+                                const truncAddr = safeDest.substring(0, 11) + '...' + safeDest.substring(safeDest.length - 6);
+                                addressHtml += `<a href="https://www.unicity.network/address/${safeDest}" target="_blank" style="color: #3b82f6; text-decoration: none;">${truncAddr}</a>`;
                             });
                             addressHtml += '</div>';
                         }
@@ -9347,6 +9413,9 @@ Anyone with your master private key can access all your funds.`;
                 const vestingBadgeHtml = vestingLabel ?
                     `<span style="font-size: 10px; padding: 1px 6px; border-radius: 3px; background-color: ${borderColor}20; color: ${borderColor}; font-weight: 600; margin-left: 8px;">${vestingLabel}</span>` : '';
 
+                // Sanitize height to integer for safe innerHTML use
+                const safeHeight = parseInt(tx.height, 10) || 0;
+
                 txDiv.innerHTML = `
                     <div style="display: flex; justify-content: space-between; align-items: start;">
                         <div style="flex: 1;">
@@ -9361,8 +9430,8 @@ Anyone with your master private key can access all your funds.`;
                             </div>
                             <div style="color: #666; font-size: 12px;">
                                 <span style="color: ${statusColor};">${statusText}</span>
-                                ${tx.height > 0 ? ` • Block ${tx.height}` : ''}
-                                <span class="block-timestamp" data-height="${tx.height}"></span>
+                                ${safeHeight > 0 ? ` &bull; Block ${safeHeight}` : ''}
+                                <span class="block-timestamp" data-height="${safeHeight}"></span>
                             </div>
                             ${addressHtml}
                         </div>
@@ -10350,9 +10419,10 @@ Anyone with your master private key can access all your funds.`;
                     const utxoDiv = document.createElement('div');
 
                     const amount = SatoshiMath.satoshisToAlpha(utxo.value);
-                    const txid = utxo.tx_hash || utxo.txid;
-                    const vout = utxo.tx_pos !== undefined ? utxo.tx_pos : utxo.vout;
-                    const height = utxo.height || 0;
+                    const rawUtxoTxid = utxo.tx_hash || utxo.txid || '';
+                    const txid = rawUtxoTxid.replace(/[^a-fA-F0-9]/g, '');
+                    const vout = parseInt(utxo.tx_pos !== undefined ? utxo.tx_pos : utxo.vout, 10) || 0;
+                    const height = parseInt(utxo.height, 10) || 0;
                     const source = utxo.source === 'offline' ? ' (imported)' : '';
                     
                     // Check if this UTXO is consumed
@@ -11059,18 +11129,32 @@ Anyone with your master private key can access all your funds.`;
                         break;
                 }
                 
-                notification.innerHTML = `
-                    <div class="notification-icon">${icon}</div>
-                    <div class="notification-content">
-                        <div class="notification-title">${title}</div>
-                        <div class="notification-message">${message}</div>
-                    </div>
-                    <button class="notification-close">&times;</button>
-                `;
-                
-                // Add close functionality
-                const closeBtn = notification.querySelector('.notification-close');
+                // Build notification DOM safely (no innerHTML with user/server data)
+                const iconDiv = document.createElement('div');
+                iconDiv.className = 'notification-icon';
+                iconDiv.textContent = icon;
+
+                const titleDiv = document.createElement('div');
+                titleDiv.className = 'notification-title';
+                titleDiv.textContent = title;
+
+                const msgDiv = document.createElement('div');
+                msgDiv.className = 'notification-message';
+                msgDiv.textContent = message;
+
+                const contentDiv = document.createElement('div');
+                contentDiv.className = 'notification-content';
+                contentDiv.appendChild(titleDiv);
+                contentDiv.appendChild(msgDiv);
+
+                const closeBtn = document.createElement('button');
+                closeBtn.className = 'notification-close';
+                closeBtn.innerHTML = '&times;';
                 closeBtn.onclick = () => removeNotification(notification);
+
+                notification.appendChild(iconDiv);
+                notification.appendChild(contentDiv);
+                notification.appendChild(closeBtn);
                 
                 // Add to container
                 container.appendChild(notification);
@@ -11191,6 +11275,23 @@ Anyone with your master private key can access all your funds.`;
             function hasArrayChanged(oldArray, newArray) {
                 return analyzeTransactionChanges(oldArray, newArray).hasChanged;
             }
+
+            // Compare UTXO arrays including vesting fields to avoid redundant reprocessing
+            function hasUtxoArrayChanged(oldUtxos, newUtxos) {
+                if (!oldUtxos || !newUtxos) return true;
+                if (oldUtxos.length !== newUtxos.length) return true;
+                const oldKeys = new Map();
+                for (const u of oldUtxos) {
+                    oldKeys.set(`${u.tx_hash}:${u.tx_pos}`, { value: u.value, height: u.height, vested: u.vested });
+                }
+                for (const u of newUtxos) {
+                    const key = `${u.tx_hash}:${u.tx_pos}`;
+                    const old = oldKeys.get(key);
+                    if (!old) return true;
+                    if (old.value !== u.value || old.height !== u.height || old.vested !== u.vested) return true;
+                }
+                return false;
+            }
             
             // Update refreshBalance to store current data
             const originalRefreshBalance = refreshBalance;
@@ -11285,16 +11386,21 @@ Anyone with your master private key can access all your funds.`;
                         electrumRequest('blockchain.scripthash.listunspent', [scriptHash], function(result) {
                             if (result) {
                                 const currentAddress = wallet.addresses[0].address;
-                                // Always update currentUtxos from server (picks up new fields like vested)
-                                currentUtxos = result.map(utxo => ({
+                                const newUtxos = result.map(utxo => ({
                                     ...utxo,
                                     address: currentAddress
                                 }));
+
+                                // Only reprocess if UTXOs actually changed
+                                const utxosChanged = hasUtxoArrayChanged(currentUtxos, newUtxos);
+                                currentUtxos = newUtxos;
                                 updateCommonBalance();
                                 updateUtxoListDisplay();
 
-                                // Process UTXOs through server-aware classification
-                                processIncomingUtxos(currentUtxos, currentAddress);
+                                // Only reprocess classification when UTXOs changed
+                                if (utxosChanged) {
+                                    processIncomingUtxos(currentUtxos, currentAddress);
+                                }
                             }
                         });
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "guiwallet",
+  "name": "webwallet",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,9 +7,11 @@
       "dependencies": {
         "bip32": "^5.0.0-rc.0",
         "bs58check": "^4.0.0",
+        "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
         "sqlite3": "^5.1.7",
-        "tiny-secp256k1": "^2.2.4"
+        "tiny-secp256k1": "^2.2.4",
+        "ws": "^8.18.3"
       }
     },
     "node_modules/@gar/promisify": {
@@ -362,6 +364,12 @@
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1618,6 +1626,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,451 @@
         "sqlite3": "^5.1.7",
         "tiny-secp256k1": "^2.2.4",
         "ws": "^8.18.3"
+      },
+      "devDependencies": {
+        "vite": "^7.3.1"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@gar/promisify": {
@@ -59,6 +504,356 @@
         "node": ">=10"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@scure/base": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
@@ -77,6 +872,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -487,6 +1289,48 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -494,6 +1338,24 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-uri-to-path": {
@@ -526,6 +1388,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/gauge": {
       "version": "4.0.4",
@@ -982,6 +1859,25 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -1109,6 +2005,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -1220,6 +2165,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -1359,6 +2349,16 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sqlite3": {
@@ -1525,6 +2525,23 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1582,6 +2599,81 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "dependencies": {
     "bip32": "^5.0.0-rc.0",
     "bs58check": "^4.0.0",
+    "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",
     "sqlite3": "^5.1.7",
-    "tiny-secp256k1": "^2.2.4"
+    "tiny-secp256k1": "^2.2.4",
+    "ws": "^8.18.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "dev": "vite"
+  },
   "dependencies": {
     "bip32": "^5.0.0-rc.0",
     "bs58check": "^4.0.0",
@@ -7,5 +10,8 @@
     "sqlite3": "^5.1.7",
     "tiny-secp256k1": "^2.2.4",
     "ws": "^8.18.3"
+  },
+  "devDependencies": {
+    "vite": "^7.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- Integrate server-side vesting classification from Fulcrum, replacing client-side coinbase tracing when the server provides `vested` fields on UTXOs
- Add vesting color indicators (Locked/Unlocked/Mixed badges) to transaction history and UTXO list
- Add vite dev server for local development
- Fix XSS vulnerabilities in `showInAppNotification` and innerHTML rendering of server-sourced data (txid, addresses, block height)
- Fix balance verification race conditions: stale `fulcrumDirectBalance` on reconnect, premature `checkBalanceVerification` before async fetch completes, stuck spinner from retry cascade
- Add UTXO change-detection guard (`hasUtxoArrayChanged`) to prevent redundant reprocessing and UI flicker
- Bump version to v0.5.0

## Test plan
- [ ] Connect to a vesting-enabled Fulcrum server — verify instant vesting classification with no spinner stuck
- [ ] Connect to a non-vesting Fulcrum server — verify legacy client-side tracing still works
- [ ] Disconnect and reconnect — verify balances reset correctly and no stale data shown
- [ ] Switch between watch-only addresses — verify vesting breakdown updates correctly
- [ ] Check transaction history for Locked/Unlocked/Mixed badges on classified transactions
- [ ] Check UTXO list for Locked/Unlocked badges with correct colors
- [ ] Verify no XSS when server returns malformed txid/address/error messages